### PR TITLE
fix for wrong behavior of write_str() function

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -196,6 +196,7 @@ namespace SudoMaker::chAT {
 
 		void write_str(std::string str) {
 			write_raw(data_holder{
+				.size = str.size(),
 				.position = 0,
 				.holder = std::move(str),
 			});


### PR DESCRIPTION
I noticed that when write_str() function is used without this fix the behavior is quite random (sometimes the written string is not "published") depending on the value of not initialized data_holder.size field